### PR TITLE
Update/v1/style

### DIFF
--- a/src/features/Top/TheTeam/Member.tsx
+++ b/src/features/Top/TheTeam/Member.tsx
@@ -10,13 +10,13 @@ type Props = {
   leftWidth?: string;
   leftLink: string;
   leftId: number;
-  rightName: string;
-  rightComment: React.ReactNode;
-  rightImage: string;
-  rightBg: string;
+  rightName?: string;
+  rightComment?: React.ReactNode;
+  rightImage?: string;
+  rightBg?: string;
   rightWidth?: string;
-  rightLink: string;
-  rightId: number;
+  rightLink?: string;
+  rightId?: number;
 };
 
 export const Member: FC<Props> = ({
@@ -47,7 +47,7 @@ export const Member: FC<Props> = ({
         borderBottom={{ base: 'none', lg: 'solid 1px' }}
         borderColor="#fff"
       >
-        <Box w="86%" m="0 auto">
+        <Box w="86%" m="0 auto" position="relative">
           <Box
             display={{ base: 'block', lg: 'flex' }}
             justifyContent="space-between"
@@ -63,22 +63,26 @@ export const Member: FC<Props> = ({
             />
             <Box
               width="1px"
+              height="80%"
               bgColor="#fff"
-              alignSelf="stretch"
-              mx="4px"
-              mt="76px"
-              mb="16px"
+              position="absolute"
+              top="50%"
+              left="50%"
+              transform="translate(-50%, -50%)"
               display={{ base: 'none', lg: 'block' }}
             />
-            <MemberContent
-              backgroundUrl={rightBg}
-              name={rightName}
-              comment={rightComment}
-              imageUrl={rightImage}
-              width={rightWidth}
-              link={rightLink}
-              id={rightId}
-            />
+
+            {rightBg && rightName && rightImage && rightLink && rightId && (
+              <MemberContent
+                backgroundUrl={rightBg}
+                name={rightName}
+                comment={rightComment}
+                imageUrl={rightImage}
+                width={rightWidth}
+                link={rightLink}
+                id={rightId}
+              />
+            )}
           </Box>
         </Box>
       </Box>

--- a/src/features/UpdateContent/index.tsx
+++ b/src/features/UpdateContent/index.tsx
@@ -46,7 +46,7 @@ export const UpdateContent = () => {
 
       <Box
         position="relative"
-        w="70%"
+        w={{ base: '85%', lg: '70%' }}
         mt="-50px"
         mb="120px"
         mx="auto"


### PR DESCRIPTION
- TopのThe Teamのメンバーが奇数にも対応できるように右側に表示する情報をoptionanlに修正
- update-contentのnewsの横幅を広げる(モバイルのみ)

![スクリーンショット 2024-12-29 2 29 54](https://github.com/user-attachments/assets/3105b520-1eb0-4c50-9c4a-d607190163f2)

![スクリーンショット 2024-12-29 3 03 49](https://github.com/user-attachments/assets/8e826edf-9887-4534-8fc0-147f79c4214b)
