### PR TITLE
Update/v1/fix schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link
+      rel="icon"
+      type="image/webp"
+      href="/images/common/ico-team-logo.webp"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script>
       (function (d) {

--- a/src/constants/scheduleWinCounter.ts
+++ b/src/constants/scheduleWinCounter.ts
@@ -20,4 +20,4 @@ export const winCounterData = [
 ];
 
 // スケジュールの表示数
-export const limit: number = 12;
+export const limit: number = 100;

--- a/src/features/Schedule/index.tsx
+++ b/src/features/Schedule/index.tsx
@@ -1,12 +1,10 @@
 import { PageLayout } from '@/components/Layouts/PageLayout';
 import { Title } from '@/components/Elements/Title';
-import { Box, Grid, Image } from '@chakra-ui/react';
+import { Box, Image } from '@chakra-ui/react';
 import { Schedule } from './Schedule';
 import { OurPartners } from '../Top/OurPartners';
 import { OfficialMedia } from '../Top/OfficialMedia';
 import { MainLayout } from '@/components/Layouts/MainLayout';
-import { WinCounter } from './WinCounter';
-import { winCounterData } from '@/constants';
 
 export const ScheduleComponent = () => {
   return (
@@ -63,7 +61,7 @@ export const ScheduleComponent = () => {
       <Schedule />
       <MainLayout>
         <Box mb={{ base: '144px', lg: '192px' }}>
-          <Grid
+          {/* <Grid
             templateColumns={{ base: 'repeat(1, 1fr)', lg: 'repeat(3, 1fr)' }}
             gap={0}
             color="#FFF"
@@ -77,7 +75,7 @@ export const ScheduleComponent = () => {
                 isLastContent={index === winCounterData.length - 1}
               />
             ))}
-          </Grid>
+          </Grid> */}
         </Box>
       </MainLayout>
       <Title title="Our partners" subTitle="Our partners" />

--- a/src/features/Top/Slider/Carousel.tsx
+++ b/src/features/Top/Slider/Carousel.tsx
@@ -13,10 +13,6 @@ interface images {
     bg?: string;
   };
   alt: string;
-  text: {
-    main: string;
-    sub: string;
-  };
   isMovie?: boolean;
 }
 
@@ -37,10 +33,7 @@ const images: images[] = [
       pc: '/movie/movie-top-pc.mp4',
     },
     alt: 'スライド0',
-    text: {
-      main: 'TCS',
-      sub: 'Racing Team',
-    },
+
     isMovie: true,
   },
   {
@@ -51,10 +44,6 @@ const images: images[] = [
       bg: '/images/top/img-slider-sp-bg01.png',
     },
     alt: 'スライド1',
-    text: {
-      main: 'TCS',
-      sub: 'Racing Team',
-    },
   },
   {
     id: 2,
@@ -64,10 +53,6 @@ const images: images[] = [
       bg: '/images/top/img-slider-sp-bg02.png',
     },
     alt: 'スライド2',
-    text: {
-      main: 'TCS',
-      sub: 'Racing Team',
-    },
   },
   {
     id: 3,
@@ -77,10 +62,6 @@ const images: images[] = [
       bg: '/images/top/img-slider-sp-bg03.png',
     },
     alt: 'スライド3',
-    text: {
-      main: 'TCS',
-      sub: 'Racing Team',
-    },
   },
 ];
 
@@ -215,11 +196,11 @@ export const Carousel = () => {
               )}
             </Box>
             <Box
+              display={{ base: 'none', lg: 'flex' }}
               position="absolute"
               top="50%"
               left={{ base: '50%', lg: '256px' }}
               transform="translate(-50%, -50%)"
-              display="flex"
               alignItems="center"
               justifyContent="center"
             >
@@ -228,14 +209,14 @@ export const Carousel = () => {
                 color="white"
                 fontWeight="bold"
               >
-                {image.text.main}
+                TCS
                 <Box as="span" fontSize="xl" ml="16px">
-                  {image.text.sub}
+                  Racing Team
                 </Box>
               </Text>
             </Box>
             <Box
-              display="flex"
+              display={{ base: 'none', lg: 'flex' }}
               flexDirection={{ base: 'column', lg: 'row' }}
               justifyContent={{ base: 'none', lg: 'center' }}
               position="absolute"


### PR DESCRIPTION
- Scheduleページのカウント表示部分の削除
- ScheduleページのカウントRaceとEventsのリスト表示の件数を増やす
- Topページのモバイルのみ、「TCS Racing Team」と「日本からアジアへそして世界へ」を削除
- ファビコン(ブラウザのバーのアイコン)を設定

![スクリーンショット 2025-03-01 18 48 37](https://github.com/user-attachments/assets/7e857c7e-74d3-4ef0-9c86-b15169e1b006)

![スクリーンショット 2025-03-01 18 48 02](https://github.com/user-attachments/assets/51f5db1a-dccd-47df-aca9-936c550daebb)

![スクリーンショット 2025-03-01 19 21 02](https://github.com/user-attachments/assets/d124402c-5a2f-46b6-b28f-a2977d0869e7)

![スクリーンショット 2025-03-01 19 19 48](https://github.com/user-attachments/assets/76f34903-965e-4fae-b886-c80e3880bbb9)


<img width="943" alt="スクリーンショット 2025-03-01 19 00 57" src="https://github.com/user-attachments/assets/161eec80-a499-4c09-8772-992e15ab5856" />
